### PR TITLE
Dockerize signaturepdf

### DIFF
--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -1,0 +1,54 @@
+name: Docker publish
+
+on:
+  push:
+    branches:
+      - 'master'
+    tags:
+      - '*.*.*'
+
+jobs:
+  docker:
+    environment: docker-registry
+    runs-on: ubuntu-latest
+    steps:
+      -
+        name: Checkout
+        uses: actions/checkout@v2
+      -
+        name: Docker meta
+        id: meta
+        uses: docker/metadata-action@v3
+        with:
+          # list of Docker images to use as base name for tags
+          images: registry.hub.docker.com/${{ secrets.DOCKER_REGISTRY_USERNAME }}/signaturepdf
+          # generate Docker tags based on the following events/attributes
+          tags: |
+            type=ref,event=branch
+            type=ref,event=pr
+            type=semver,pattern={{version}}
+            type=semver,pattern={{major}}.{{minor}}
+            type=semver,pattern={{major}}
+      -
+        name: Set up QEMU
+        uses: docker/setup-qemu-action@v1
+      -
+        name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v1
+      -
+        name: Login to registry
+        uses: docker/login-action@v1
+        with:
+          registry: registry.hub.docker.com
+          username: xgaia
+          password: ${{ secrets.DOCKER_REGISTRY_TOKEN }}
+      -
+        name: Build and push
+        uses: docker/build-push-action@v2
+        with:
+          context: .
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          secrets: |
+            GIT_AUTH_TOKEN=${{ secrets.DOCKER_REGISTRY_TOKEN }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,18 +1,22 @@
 FROM php:7.4-apache
 
 ENV SERVERNAME=localhost
+ENV UPLOAD_MAX_FILESIZE=24M
+ENV POST_MAX_SIZE=24M
+ENV MAX_FILE_UPLOADS=201
 
 RUN apt update && apt install -y gettext-base librsvg2-bin pdftk imagemagick potrace
 
 COPY . /usr/local/signaturepdf
 
 RUN chown -R www-data:www-data /usr/local/signaturepdf && chmod 750 -R /usr/local/signaturepdf && \
-    cp /usr/local/signaturepdf/php.ini /usr/local/etc/php/conf.d/uploads.ini && \
-    cat /usr/local/signaturepdf/apache.conf | envsubst > /etc/apache2/sites-available/signaturepdf.conf && \
+    envsubst < /usr/local/signaturepdf/php.ini > /usr/local/etc/php/conf.d/uploads.ini && \
+    envsubst < /usr/local/signaturepdf/apache.conf > /etc/apache2/sites-available/signaturepdf.conf && \
          a2enmod rewrite && a2ensite signaturepdf
 
 WORKDIR /usr/local/signaturepdf
 
 CMD envsubst < /usr/local/signaturepdf/apache.conf > /etc/apache2/sites-available/signaturepdf.conf && \
+    envsubst < /usr/local/signaturepdf/php.ini > /usr/local/etc/php/conf.d/uploads.ini && \
     chown -R www-data:www-data /usr/local/signaturepdf && chmod 750 -R /usr/local/signaturepdf && \
     apache2-foreground

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,18 @@
+FROM php:7.4-apache
+
+ENV SERVERNAME=localhost
+
+RUN apt update && apt install -y gettext-base librsvg2-bin pdftk imagemagick potrace
+
+COPY . /usr/local/signaturepdf
+
+RUN chown -R www-data:www-data /usr/local/signaturepdf && chmod 750 -R /usr/local/signaturepdf && \
+    cp /usr/local/signaturepdf/php.ini /usr/local/etc/php/conf.d/uploads.ini && \
+    cat /usr/local/signaturepdf/apache.conf | envsubst > /etc/apache2/sites-available/signaturepdf.conf && \
+         a2enmod rewrite && a2ensite signaturepdf
+
+WORKDIR /usr/local/signaturepdf
+
+CMD envsubst < /usr/local/signaturepdf/apache.conf > /etc/apache2/sites-available/signaturepdf.conf && \
+    chown -R www-data:www-data /usr/local/signaturepdf && chmod 750 -R /usr/local/signaturepdf && \
+    apache2-foreground

--- a/README.md
+++ b/README.md
@@ -77,7 +77,7 @@ docker build -t signaturepdf .
 docker run -d --name=signaturepdf -p 8080:80 signaturepdf
 ````
 
-[localhost:8080](localhost:8080)
+[localhost:8080](http://localhost:8080)
 
 #### Configuration
 
@@ -86,8 +86,8 @@ Les variables suivantes permettent de configurer le déployement :
 |Variable|description|exemple|defaut|
 |-----|-----|-----|-----|
 |`SERVERNAME`|url de déploiement|`pdf.24eme.fr`|localhost|
-|`UPLOAD_MAX_FILESIZE`|Taille maximum du fichier PDF à signer|48|24M|
-|`POST_MAX_SIZE`|Taille maximum du fichier PDF à signer|48|24M|
+|`UPLOAD_MAX_FILESIZE`|Taille maximum du fichier PDF à signer|48M|24M|
+|`POST_MAX_SIZE`|Taille maximum du fichier PDF à signer|48M|24M|
 |`MAX_FILE_UPLOADS`|Nombre de pages maximum du PDF, ici 200 pages + le PDF d'origine|401|201|
 
 ```bash

--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@ Logiciel web libre permettant de signer un PDF.
 Liste des instances permettant d'utiliser ce logiciel :
 
 - [pdf.24eme.fr](https://pdf.24eme.fr)
+- [pdf.libreon.fr](https://pdf.libreon.fr)
 
 ## License
 
@@ -61,6 +62,37 @@ DocumentRoot /path/to/signaturepdf/public
     php_value post_max_size 24M
 </Directory>
 ```
+
+### Déployer avec docker
+
+#### Construction de l'image
+
+```bash
+docker build -t signaturepdf .
+````
+
+#### Lancement d'un conteneur
+
+```bash
+docker run -d --name=signaturepdf -p 8080:80 signaturepdf
+````
+
+[localhost:8080](localhost:8080)
+
+#### Configuration
+
+Les variables suivantes permettent de configurer le déployement :
+
+|Variable|description|exemple|defaut|
+|-----|-----|-----|-----|
+|`SERVERNAME`|url de déploiement|`pdf.24eme.fr`|localhost|
+|`UPLOAD_MAX_FILESIZE`|Taille maximum du fichier PDF à signer|48|24M|
+|`POST_MAX_SIZE`|Taille maximum du fichier PDF à signer|48|24M|
+|`MAX_FILE_UPLOADS`|Nombre de pages maximum du PDF, ici 200 pages + le PDF d'origine|401|201|
+
+```bash
+docker run -d --name=signaturepdf -p 8080:80 -e SERVERNAME=pdf.example.org -e UPLOAD_MAX_FILESIZE=48M -e POST_MAX_SIZE=48M -e MAX_FILE_UPLOADS=401 signaturepdf
+````
 
 ## Tests
 

--- a/apache.conf
+++ b/apache.conf
@@ -1,0 +1,22 @@
+<VirtualHost *:80>
+    ServerName ${SERVERNAME}
+    DocumentRoot /usr/local/signaturepdf/public
+    DirectoryIndex index.php
+
+    AddDefaultCharset UTF-8
+
+    <Directory /usr/local/signaturepdf/public>
+          AllowOverride All
+        <IfVersion >= 2.3>
+            Require all granted
+        </IfVersion>
+        <IfVersion < 2.3>
+            Order Deny,Allow
+            Allow from all
+        </IfVersion>
+    </Directory>
+
+    LogLevel warn
+    ErrorLog /var/log/apache2/ssp_error.log
+    CustomLog /var/log/apache2/ssp_access.log combined
+</VirtualHost>

--- a/php.ini
+++ b/php.ini
@@ -1,0 +1,3 @@
+upload_max_filesize = 24M
+post_max_size = 24M
+max_file_uploads = 201

--- a/php.ini
+++ b/php.ini
@@ -1,3 +1,3 @@
-upload_max_filesize = 24M
-post_max_size = 24M
-max_file_uploads = 201
+upload_max_filesize = $UPLOAD_MAX_FILESIZE
+post_max_size = $POST_MAX_SIZE
+max_file_uploads = $MAX_FILE_UPLOADS


### PR DESCRIPTION
Hello, here is a Dockerfile for signaturepdf. (fix #22 )

- Dockerfile
- GitHub action to auto-build and publish the docker image on dockehub (you will need to configure `DOCKER_REGISTRY_USERNAME` and `DOCKER_REGISTRY_TOKEN` into the project configuration. You can find help on this PR : https://github.com/wheelybird/ldap-user-manager/pull/134)
- Docs (in `README.md`)

[pdf.libreon.fr](https://pdf.libreon.fr) use this docker image.

Tel me if you don't want the auto-build, i will remove it. 