### PR TITLE
feat(docker): update dockerfile to enable pdf storage for multi-signature

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,19 +4,20 @@ ENV SERVERNAME=localhost
 ENV UPLOAD_MAX_FILESIZE=24M
 ENV POST_MAX_SIZE=24M
 ENV MAX_FILE_UPLOADS=201
+ENV PDF_STORAGE_PATH=
 
-RUN apt update && apt install -y gettext-base librsvg2-bin pdftk imagemagick potrace
+RUN apt update && \
+    apt install -y gettext-base librsvg2-bin pdftk imagemagick potrace
 
 COPY . /usr/local/signaturepdf
 
 RUN chown -R www-data:www-data /usr/local/signaturepdf && chmod 750 -R /usr/local/signaturepdf && \
+    chmod 775 -R /usr/local/signaturepdf/entrypoint.sh && \
     envsubst < /usr/local/signaturepdf/config/php.ini > /usr/local/etc/php/conf.d/uploads.ini && \
     envsubst < /usr/local/signaturepdf/config/apache.conf > /etc/apache2/sites-available/signaturepdf.conf && \
+    envsubst < /usr/local/signaturepdf/config/config.ini.tpl > /usr/local/signaturepdf/config/config.ini && \
          a2enmod rewrite && a2ensite signaturepdf
 
 WORKDIR /usr/local/signaturepdf
 
-CMD envsubst < /usr/local/signaturepdf/config/apache.conf > /etc/apache2/sites-available/signaturepdf.conf && \
-    envsubst < /usr/local/signaturepdf/config/php.ini > /usr/local/etc/php/conf.d/uploads.ini && \
-    chown -R www-data:www-data /usr/local/signaturepdf && chmod 750 -R /usr/local/signaturepdf && \
-    apache2-foreground
+CMD /usr/local/signaturepdf/entrypoint.sh

--- a/README.md
+++ b/README.md
@@ -75,7 +75,7 @@ Créer le fichier `config/config.ini`
 cp config/config.ini{.example,}
 ```
 
-Dans ce fichier `config/config.ini`, il suffit ce configurer la variable `PDF_STORAGE_PATH` avec le chemin vers lequel les fichiers pdf uploadé pourront être stockés :
+Dans ce fichier `config/config.ini`, il suffit ce configurer la variable `PDF_STORAGE_PATH` avec le chemin vers lequel les fichiers pdf uploadés pourront être stockés :
 ```
 PDF_STORAGE_PATH=/path/to/folder
 ```
@@ -118,9 +118,10 @@ Les variables suivantes permettent de configurer le déployement :
 |`UPLOAD_MAX_FILESIZE`|Taille maximum du fichier PDF à signer|48M|24M|
 |`POST_MAX_SIZE`|Taille maximum du fichier PDF à signer|48M|24M|
 |`MAX_FILE_UPLOADS`|Nombre de pages maximum du PDF, ici 200 pages + le PDF d'origine|401|201|
+|`PDF_STORAGE_PATH`|chemin vers lequel les fichiers pdf uploadés pourront être stockés|/data||
 
 ```bash
-docker run -d --name=signaturepdf -p 8080:80 -e SERVERNAME=pdf.example.org -e UPLOAD_MAX_FILESIZE=48M -e POST_MAX_SIZE=48M -e MAX_FILE_UPLOADS=401 signaturepdf
+docker run -d --name=signaturepdf -p 8080:80 -e SERVERNAME=pdf.example.org -e UPLOAD_MAX_FILESIZE=48M -e POST_MAX_SIZE=48M -e MAX_FILE_UPLOADS=401 -e PDF_STORAGE_PATH=/data signaturepdf
 ````
 
 ## Tests

--- a/config/config.ini.tpl
+++ b/config/config.ini.tpl
@@ -1,0 +1,5 @@
+[globals]
+
+# Path to which stored pdf to activate the mode of sharing a signature to several.
+# To deactivate this mode, simply do not configure it or leave it empty
+PDF_STORAGE_PATH=${PDF_STORAGE_PATH}

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,0 +1,17 @@
+#! /bin/bash
+
+envsubst < /usr/local/signaturepdf/config/apache.conf > /etc/apache2/sites-available/signaturepdf.conf
+
+envsubst < /usr/local/signaturepdf/config/php.ini > /usr/local/etc/php/conf.d/uploads.ini
+
+envsubst < /usr/local/signaturepdf/config/config.ini.tpl > /usr/local/signaturepdf/config/config.ini
+
+chown -R www-data:www-data /usr/local/signaturepdf && chmod 750 -R /usr/local/signaturepdf
+
+if [[ ! -z $PDF_STORAGE_PATH ]] ; then
+    mkdir -p $PDF_STORAGE_PATH
+    chown -R www-data:www-data $PDF_STORAGE_PATH
+    chmod 750 -R $PDF_STORAGE_PATH
+fi
+
+apache2-foreground


### PR DESCRIPTION
Hello,

Here is a pull-request to enable “multi-signature” in the Docker image.

I had to create a new file “config.ini.tpl” which is a template for config.ini. It was not easy to re-use “config.ini” without doing any complicated stuff. I also had to move the `CMD` commands to a script, because of the condition (does the `PDF_STORAGE_PATH` is defined ?) which could not be included in the existing CMD.

Thank you again for the multi-signature option !