### PR TITLE
fix owner of the data dir

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -6,6 +6,7 @@ envsubst < /usr/local/signaturepdf/config/config.ini.tpl > /usr/local/signaturep
 
 if [[ ! -z $PDF_STORAGE_PATH ]] ; then
     mkdir -p $PDF_STORAGE_PATH
+    chown www-data:www-data $PDF_STORAGE_PATH
 fi
 
 apache2-foreground


### PR DESCRIPTION
L'image docker ne fonctionne pas pour la signature à plusieurs car le répertoire `/data` n'a pas les bon droits. Cette PR fix le problème.

Xavier