### PR TITLE
Fix Call to undefined function bindtextdomain()

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,6 +10,7 @@ ENV PDF_DEMO_LINK=true
 
 RUN apt update && \
     apt install -y gettext-base librsvg2-bin pdftk imagemagick potrace && \
+    docker-php-ext-install gettext && \
     rm -rf /var/lib/apt/lists/*
 
 COPY . /usr/local/signaturepdf

--- a/compose.yaml
+++ b/compose.yaml
@@ -1,0 +1,6 @@
+version: '3.7'
+services:
+  signaturepdf:
+    build: .
+    ports:
+      - "8080:80"


### PR DESCRIPTION
Install PHP gettext extensions in Docker Image.
Added a Docker Compose file.