### PR TITLE
New public instance : https://pdf.ti-nuage.fr.

### DIFF
--- a/README.fr.md
+++ b/README.fr.md
@@ -12,6 +12,7 @@ Liste des instances permettant d'utiliser ce logiciel :
 - [pdf.libreon.fr](https://pdf.libreon.fr)
 - [pdf.hostux.net](https://pdf.hostux.net)
 - [pdf.nebulae.co](https://pdf.nebulae.co)
+- [pdf.ti-nuage.fr](https://pdf.ti-nuage.fr)
 
 _N'hésitez pas à rajouter la votre via une issue ou une pull request_
 

--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@ List of instances where you can use this software:
 - [pdf.hostux.net](https://pdf.hostux.net)
 - [pdf.nebulae.co](https://pdf.nebulae.co)
 - [pdf.kaosx.cf](https://pdf.kaosx.cf)
+- [pdf.ti-nuage.fr](https://pdf.ti-nuage.fr)
 
 _Feel free to add yours through an issue or a pull request._
 


### PR DESCRIPTION
Because this is a very neat software, we are offering a new instance here. Ti Nuage is a member of chatons.org.
Thanks for this piece of work.