### PR TITLE
Compression automatique des fichiers lors d'extraction de pages

### DIFF
--- a/app.php
+++ b/app.php
@@ -422,10 +422,11 @@ $f3->route ('POST /compress',
             $compressionType = '/ebook';
         } elseif ($compressionType === 'low') {
             $compressionType = '/printer';
+        } elseif ($compressionType === 'highest') {
+            $compressionType = '/prepress';  
         } else {
             $compressionType = '/screen';
         }
-
         $arrayPath = array_keys($files);
         $filePath = reset($arrayPath);
 

--- a/public/js/organization.js
+++ b/public/js/organization.js
@@ -590,7 +590,7 @@ async function save(order) {
     // Let's try to compress our PDF using the compress feature
     let data = new FormData();
     data.append("input_pdf_upload", newPDF, filename + ".pdf");
-    data.append("compressionType", "screen");
+    data.append("compressionType", "highest");
     const response = await fetch("/compress", {method: "POST", body: data});
     let compressedBlob = null;
     if (response.status == 200) {


### PR DESCRIPTION
Cette MR règle l'issue #98.

Le soucis vient de PDF-lib, qui génère des fichiers anormalement gros. J'ai cherché mais je n'ai pas trouvé d'options dans PDF-lib permettant de contrôler ça. Le seul conseil que j'ai vu indiquait de faire un `.save({useObjectStreams: true})`, mais je n'ai pas vu de différence sur la taille des PDF générés.

Du coup, j'ai rajouté, uniquement lors de l'extraction, un appel à /compress pour compresser le fichier côté serveur, ainsi qu'un nouveau mode de compression, qui est censé être le plus haute qualité de ghostscript (si j'ai bien compris !).

Sur mes tests, je n'ai pas vu de différence de qualité entre sans/avec la compression, mais il pourrait être intéressant de rajouter une checkbox dans l'interface (mais où ?) pour activer/désactiver la compression automatique