### PR TITLE
add specific CSS loading if exists, refers to #133

### DIFF
--- a/templates/signature.html.php
+++ b/templates/signature.html.php
@@ -10,6 +10,9 @@
     <link href="<?php echo $REVERSE_PROXY_URL; ?>/vendor/bootstrap.<?php echo $DIRECTION_LANGUAGE ?>.min.css?5.3.3" rel="stylesheet">
     <link href="<?php echo $REVERSE_PROXY_URL; ?>/vendor/bootstrap-icons.min.css?1.11.3" rel="stylesheet">
     <link href="<?php echo $REVERSE_PROXY_URL; ?>/css/app.css?<?php echo ($COMMIT) ? $COMMIT : filemtime($ROOT."/public/css/app.css") ?>" rel="stylesheet">
+    <?php if (file_exists($ROOT."/public/css/app-specific.css")): ?>
+    <link href="<?php echo $REVERSE_PROXY_URL; ?>/css/app-specific.css?<?php echo ($COMMIT) ? $COMMIT : filemtime($ROOT."/public/css/app-specific.css") ?>" rel="stylesheet">
+    <?php endif; ?>
 </head>
 <body>
 <noscript>


### PR DESCRIPTION
Comme proposé dans #133 , ce patch propose de charger une CSS finale qui surcharge éventuellement les styles.

L'objectif de cette surcharge est de permettre de monter (dans docker par exemple) un seul fichier qui "applique" les CSS demandées pour les éléments souhaités.

Le nom et le placement de cette css sont écrits dans le code : `/public/css/app-specific.css`, la ligne `<link>` n'est générée que si le fichier existe.

On peut par exemple contrôler l'affichage des outils de la manière suivante :

```css
// hide initials
div.list-item-add:has(#label_svg_initials_add){
  display: none !important;
}

//hide stamp
div.list-item-add:has(#radio_svg_rubber_stamber_add){
  display: none !important;
}

// hide text
div.list-item-add:has(#radio_svg_text){
  display: none !important;
}

// hide strike
div.list-item-add:has(#label_svg_strikethrough){
  display: none !important;
}

// Hide checks
div.list-item-add:has(#label_svg_check){
  display: none !important;
}       

// Hide add button
#btn-add-svg{
        display: none !important;
}

```

I hope this may help others to hide/show different tools.