### PR TITLE
Use the configured reverse proxy URL for font paths and JS routing

### DIFF
--- a/public/css/app.css
+++ b/public/css/app.css
@@ -1,17 +1,3 @@
-@font-face {
-    font-family: 'Caveat';
-    font-style: normal;
-    font-weight: 400;
-    src: url(/vendor/fonts/Caveat-Regular.ttf) format('truetype');
-}
-
-@font-face {
-    font-family: 'Tajawal';
-    font-style: normal;
-    font-weight: 400;
-    src: url(/vendor/fonts/Tajawal-Medium.ttf) format('truetype');
-}
-
 #container-pages {
     overflow: auto;
 }

--- a/public/js/metadata.js
+++ b/public/js/metadata.js
@@ -330,7 +330,7 @@ async function pageUpload() {
         if(await canUseCache()) {
             const file = document.getElementById('input_pdf_upload').files[0]
             storeFileInCache(file, file.name);
-            history.pushState({}, '', '/metadata#'+file.name);
+            history.pushState({}, '', `${REVERSE_PROXY_URL ? '/': ''}${REVERSE_PROXY_URL}/metadata#${file.name}`);
         }
         pageMetadata(null);
     });

--- a/public/js/signature.js
+++ b/public/js/signature.js
@@ -1176,7 +1176,7 @@ async function pageUpload() {
         if(await canUseCache()) {
             const file = document.getElementById('input_pdf_upload').files[0]
             storeFileInCache(file, file.name);
-            history.pushState({}, '', '/signature#'+file.name);
+            history.pushState({}, '', `${REVERSE_PROXY_URL ? '/': ''}${REVERSE_PROXY_URL}/signature#${file.name}`);
         }
         pageSignature(null);
     });

--- a/templates/components/common.html.php
+++ b/templates/components/common.html.php
@@ -21,6 +21,7 @@
 <?php endif; ?>
 <script src="<?php echo $REVERSE_PROXY_URL; ?>/js/common.js?<?php echo ($COMMIT) ? $COMMIT : filemtime($ROOT."/public/js/common.js") ?>"></script>
 <script>
+var REVERSE_PROXY_URL = <?php echo json_encode($REVERSE_PROXY_URL); ?>;
 var trad = <?php echo json_encode([
     'Select this page' => _('Select this page'),
     'Delete this page' => _('Delete this page'),

--- a/templates/components/header.html.php
+++ b/templates/components/header.html.php
@@ -8,3 +8,18 @@
 <?php endif; ?>
 <link rel="icon" type="image/x-icon" href="<?php echo $REVERSE_PROXY_URL; ?>/favicon.ico">
 <link rel="icon" type="image/png" sizes="192x192" href="<?php echo $REVERSE_PROXY_URL; ?>/favicon.png" />
+<style>
+    @font-face {
+        font-family: 'Caveat';
+        font-style: normal;
+        font-weight: 400;
+        src: url('<?php echo $REVERSE_PROXY_URL; ?>/vendor/fonts/Caveat-Regular.ttf') format('truetype');
+    }
+
+    @font-face {
+        font-family: 'Tajawal';
+        font-style: normal;
+        font-weight: 400;
+        src: url('<?php echo $REVERSE_PROXY_URL; ?>/vendor/fonts/Tajawal-Medium.ttf') format('truetype');
+    }
+</style>

--- a/templates/signature.html.php
+++ b/templates/signature.html.php
@@ -351,11 +351,11 @@
     ]); ?>;
 
     <?php if ($TRANSLATION_LANGUAGE == 'ar'): ?>
-    url_font = <?php echo json_encode('/vendor/fonts/Tajawal-Medium.ttf') ?>
+    url_font = <?php echo json_encode((!empty($REVERSE_PROXY_URL) ? '/': '') . $REVERSE_PROXY_URL . '/vendor/fonts/Tajawal-Medium.ttf') ?>
     <?php elseif ($TRANSLATION_LANGUAGE == 'kab'): ?>
-    url_font = <?php echo json_encode('/vendor/fonts/FiraSans-MediumItalic.ttf') ?>
+    url_font = <?php echo json_encode((!empty($REVERSE_PROXY_URL) ? '/': '') . $REVERSE_PROXY_URL . '/vendor/fonts/FiraSans-MediumItalic.ttf') ?>
     <?php else: ?>
-    url_font = <?php echo json_encode('/vendor/fonts/Caveat-Regular.ttf') ?>
+    url_font = <?php echo json_encode((!empty($REVERSE_PROXY_URL) ? '/': '') . $REVERSE_PROXY_URL . '/vendor/fonts/Caveat-Regular.ttf') ?>
     <?php endif; ?>
     </script>
     <script src="<?php echo $REVERSE_PROXY_URL; ?>/js/signature.js?<?php echo ($COMMIT) ? $COMMIT : filemtime($ROOT."/public/js/signature.js") ?>"></script>


### PR DESCRIPTION
This ensures that fonts can still be loaded when a reverse proxy URL is configured and JS history state is changed to the appropriate paths.