### PR TITLE
Expand Debian deps

### DIFF
--- a/installation.md
+++ b/installation.md
@@ -16,7 +16,7 @@ Dependencies:
 
 Installing dependencies:
 ```
-sudo apt-get install php php-fileinfo php-gd php-mbstring librsvg2-bin pdftk imagemagick potrace ghostscript locales gpg
+sudo apt-get install php php-gd php-mbstring librsvg2-bin pdftk imagemagick potrace ghostscript locales gpg
 ```
 
 Getting the source code:

--- a/installation.md
+++ b/installation.md
@@ -5,7 +5,6 @@
 Dependencies:
 
 - php >= 5.6
-- php-fileinfo
 - php-gd
 - php-mbstring
 - librsvg2-bin (rsvg-convert)

--- a/installation.md
+++ b/installation.md
@@ -5,6 +5,9 @@
 Dependencies:
 
 - php >= 5.6
+- php-fileinfo
+- php-gd
+- php-mbstring
 - librsvg2-bin (rsvg-convert)
 - pdftk
 - imagemagick
@@ -14,7 +17,7 @@ Dependencies:
 
 Installing dependencies:
 ```
-sudo apt-get install php librsvg2-bin pdftk imagemagick potrace ghostscript locales gpg
+sudo apt-get install php php-fileinfo php-gd php-mbstring librsvg2-bin pdftk imagemagick potrace ghostscript locales gpg
 ```
 
 Getting the source code:


### PR DESCRIPTION
Debian's PHP ecosystem is modular, hence extensions `GD`, `Fileinfo` and `Multibyte String` need to be installed separately.

Expand the `installation.md`/Debian section to cover these additional deps (otherwise the app crashes whenever user reaches the part that depends on these)