### PR TITLE
Fix fatal error on signature page: missing php-intl extension

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,8 +10,8 @@ ENV DEFAULT_LANGUAGE=fr_FR.UTF-8
 ENV PDF_STORAGE_ENCRYPTION=false
 
 RUN apt update && \
-    apt install -y vim locales gettext-base librsvg2-bin pdftk imagemagick potrace ghostscript gpg && \
-    docker-php-ext-install gettext && \
+    apt install -y vim locales gettext-base librsvg2-bin pdftk imagemagick potrace ghostscript gpg libicu-dev && \
+    docker-php-ext-install gettext intl && \
     rm -rf /var/lib/apt/lists/*
 
 COPY . /usr/local/signaturepdf

--- a/README.fr.md
+++ b/README.fr.md
@@ -45,7 +45,7 @@ Dépendances :
 Installation des dépendances :
 
 ```
-sudo aptitude install php librsvg2-bin pdftk imagemagick potrace
+sudo aptitude install php php-intl librsvg2-bin pdftk imagemagick potrace
 ```
 
 Récupération des sources :
@@ -144,7 +144,7 @@ Ce que fait le script :
 domain='sign.example.com'
 
 apk update
-apk add bash nginx git php8 php8-fpm php8-session php8-gd php8-fileinfo openjdk8 imagemagick potrace librsvg
+apk add bash nginx git php8 php8-fpm php8-session php8-gd php8-fileinfo php8-intl php8-gettext php8-mbstring openjdk8 imagemagick potrace librsvg
 
 cd /tmp
 wget https://gitlab.com/pdftk-java/pdftk/-/jobs/924565145/artifacts/raw/build/libs/pdftk-all.jar

--- a/composer.json
+++ b/composer.json
@@ -10,7 +10,10 @@
     ],
     "minimum-stability": "stable",
     "require": {
-        "php": ">=7.2"
+        "php": ">=7.2",
+        "ext-gettext": "*",
+        "ext-mbstring": "*",
+        "ext-intl": "*"
     },
     "autoload": {
         "classmap": ["lib/"]

--- a/installation.md
+++ b/installation.md
@@ -14,7 +14,7 @@ Dependencies:
 
 Installing dependencies:
 ```
-sudo apt-get install php librsvg2-bin pdftk imagemagick potrace ghostscript locales gpg
+sudo apt-get install php php-intl librsvg2-bin pdftk imagemagick potrace ghostscript locales gpg
 ```
 
 Getting the source code:
@@ -139,7 +139,7 @@ What the script does:
 domain='sign.example.com'
 
 apk update
-apk add bash nginx git php8 php8-fpm php8-session php8-gd php8-fileinfo openjdk8 imagemagick potrace librsvg locales gpg ghostcript
+apk add bash nginx git php8 php8-fpm php8-session php8-gd php8-fileinfo php8-intl php8-gettext php8-mbstring openjdk8 imagemagick potrace librsvg locales gpg ghostcript
 
 cd /tmp
 wget https://gitlab.com/pdftk-java/pdftk/-/jobs/924565145/artifacts/raw/build/libs/pdftk-all.jar


### PR DESCRIPTION
The date formatting introduced by @gpoma in [54a7c47](https://github.com/24eme/signaturepdf/commit/54a7c47a8adc3b62c1c1415388ebc8c7eb4cb843) uses `IntlDateFormatter`, but the `intl` extension was never installed or declared. 

The Docker image and local installations without implicit installed `intl` fatals on `Fix fatal error on signature page: missing php-intl extension`