### PR TITLE
Increase PHP-container to a supported version

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM php:8.2-apache
+FROM php:8.4-apache
 
 ENV SERVERNAME=localhost
 ENV UPLOAD_MAX_FILESIZE=24M


### PR DESCRIPTION
PHP8.5 would be more recent, but would require update of the fatfree framework as it threats the deprecation of `$http_response_header` as fatal error.